### PR TITLE
Fix updateControlled bug

### DIFF
--- a/the.js
+++ b/the.js
@@ -22,9 +22,9 @@ function Game() {
 	this.expected = 25;
 
 	this.rows = [];
-	for (var i = 0; i < this.size; i ++) {
+	for (var i = 0; i < this.size; i++) {
 		var row = [];
-		for (var j = 0; j < this.size; j ++) {
+		for (var j = 0; j < this.size; j++) {
 			row.push(new Square(this));
 		}
 		this.rows.push(row);
@@ -40,8 +40,8 @@ Game.prototype.reset = function reset() {
 
 	this.moveCount = 0;
 
-	for (var i = 0; i < this.size; i ++) {
-		for (var j = 0; j < this.size; j ++) {
+	for (var i = 0; i < this.size; i++) {
+		for (var j = 0; j < this.size; j++) {
 			this.rows[i][j].reset();
 		}
 	}
@@ -51,44 +51,67 @@ Game.prototype.reset = function reset() {
 
 };
 
-Game.prototype.updateControlled = function updateControlled() {
+Game.prototype.getNeighbors = function getNeighbors(i, j) {
+	var color = this.rows[i][j].color;
+	var neighbors = [];
 
-	for (var i = 0; i < this.size; i ++) {
-		for (var j = 0; j < this.size; j ++) {
-
-			if (this.rows[i][j].controlled) {
-
-				var color = this.rows[i][j].color;
-
-				if (i > 0) {
-					var up = this.rows[i - 1][j];
-					if (up.color == color)
-						up.controlled = true;
-				}
-
-				if (i < (this.size - 1)) {
-					var down = this.rows[i + 1][j];
-					if (down.color == color)
-						down.controlled = true;
-				}
-
-				if (j > 0) {
-					var left = this.rows[i][j - 1];
-					if (left.color == color)
-						left.controlled = true;
-				}
-
-				if (j < (this.size - 1)) {
-					var right = this.rows[i][j + 1];
-					if (right.color == color)
-						right.controlled = true;
-				}
-
-			}
-
+	if (i > 0) {
+		var up = this.rows[i - 1][j];
+		if (up.color == color && !up.controlled) {
+			up.controlled = true;
+			neighbors.push([i - 1, j]);
 		}
 	}
 
+	if (i < (this.size - 1)) {
+		var down = this.rows[i + 1][j];
+		if (down.color == color && !down.controlled) {
+			down.controlled = true;
+			neighbors.push([i + 1, j]);
+		}
+	}
+
+	if (j > 0) {
+		var left = this.rows[i][j - 1];
+		if (left.color == color && !left.controlled) {
+			left.controlled = true;
+			neighbors.push([i, j - 1]);
+		}
+	}
+
+	if (j < (this.size - 1)) {
+		var right = this.rows[i][j + 1];
+		if (right.color == color && !right.controlled) {
+			right.controlled = true;
+			neighbors.push([i, j + 1]);
+		}
+	}
+
+	return neighbors;
+}
+
+Game.prototype.updateControlled = function updateControlled() {
+	var queue = [];
+	for (var i = 0; i < this.size; i++) {
+		for (var j = 0; j < this.size; j++) {
+			if (this.rows[i][j].controlled) {
+				var neighbors = this.getNeighbors(i, j);
+				for (var n = 0; n < neighbors.length; n++) {
+					queue.push(neighbors[n]);
+				}
+			}
+		}
+	}
+
+	while (queue.length > 0) {
+		var cur = queue.shift();
+		var i = cur[0];
+		var j = cur[1];
+		var neighbors = this.getNeighbors(i, j);
+		for (var n = 0; n < neighbors.length; n++) {
+			queue.push(neighbors[n]);
+		}
+	}
 };
 
 Game.prototype.flood = function flood(color) {
@@ -96,13 +119,12 @@ Game.prototype.flood = function flood(color) {
 	if (this.rows[0][0].color == color)
 		return;
 
-	this.moveCount ++;
+	this.moveCount++;
 
 	this.rows[0][0].color = color;
 
-	var queue = [];
-	for (var i = 0; i < this.size; i ++) {
-		for (var j = 0; j < this.size; j ++) {
+	for (var i = 0; i < this.size; i++) {
+		for (var j = 0; j < this.size; j++) {
 			if (this.rows[i][j].controlled) {
 				this.rows[i][j].color = color;
 			}
@@ -113,9 +135,9 @@ Game.prototype.flood = function flood(color) {
 
 	if (this.hasWon()) {
 		var me = this;
-		setTimeout(function() {
+		setTimeout(function () {
 			if (me.moveCount <= me.expected)
-				me.expected --;
+				me.expected--;
 			me.reset();
 		}, 2000);
 	}
@@ -124,8 +146,8 @@ Game.prototype.flood = function flood(color) {
 
 Game.prototype.hasWon = function hasWon() {
 	var firstColor = this.rows[0][0].color;
-	for (var i = 0; i < this.size; i ++) {
-		for (var j = 0; j < this.size; j ++) {
+	for (var i = 0; i < this.size; i++) {
+		for (var j = 0; j < this.size; j++) {
 			if (this.rows[i][j].color != firstColor) {
 				return false;
 			}


### PR DESCRIPTION
Hi there, I played this game for a bit and noticed an occasional bug that occurs when you're taking over new territories. The issue is that the `updateControlled` function loops over the board left-to-right/top-to-bottom, marking tiles as controlled if they're next to a tile that's already been marked as controlled. However, when you take over a tunnel-like territory that snakes upwards or to the left, this method isn't able to mark the whole territory as controlled. And then when you click a different color, you'll lose that territory. So I changed `updateControlled` to do a small BFS that finds all the new tiles that need to be marked as controlled. 